### PR TITLE
BLE communication refactoring

### DIFF
--- a/app/src/main/java/com/fidesmo/ble/client/apdu/ApduFragmenter.java
+++ b/app/src/main/java/com/fidesmo/ble/client/apdu/ApduFragmenter.java
@@ -1,0 +1,8 @@
+package com.fidesmo.ble.client.apdu;
+
+public interface ApduFragmenter {
+
+    byte[][] decode(byte[] encodedApdus);
+    byte[] encode(byte[][] apdus);
+
+}

--- a/app/src/main/java/com/fidesmo/ble/client/apdu/CustomFragmentationProtocol.java
+++ b/app/src/main/java/com/fidesmo/ble/client/apdu/CustomFragmentationProtocol.java
@@ -1,0 +1,9 @@
+package com.fidesmo.ble.client.apdu;
+
+import com.fidesmo.ble.client.protocol.PacketFragmenter;
+
+public interface CustomFragmentationProtocol {
+    PacketFragmenter fragmenter(int var1, byte[] var2);
+
+    CustomPacketDefragmenter deframenter();
+}

--- a/app/src/main/java/com/fidesmo/ble/client/apdu/CustomPacketDefragmenter.java
+++ b/app/src/main/java/com/fidesmo/ble/client/apdu/CustomPacketDefragmenter.java
@@ -1,0 +1,16 @@
+package com.fidesmo.ble.client.apdu;
+
+
+public interface CustomPacketDefragmenter {
+    void clear();
+
+    void append(byte[] buffer);
+
+    void add(byte[] buffer);
+
+    boolean complete();
+
+    boolean empty();
+
+    byte[] getBuffer();
+}

--- a/app/src/main/java/com/fidesmo/ble/client/apdu/CustomPacketFragmenter.java
+++ b/app/src/main/java/com/fidesmo/ble/client/apdu/CustomPacketFragmenter.java
@@ -1,0 +1,123 @@
+package com.fidesmo.ble.client.apdu;
+
+
+import android.util.Log;
+
+import com.fidesmo.ble.client.BleUtils;
+import com.fidesmo.ble.client.protocol.PacketFragmenter;
+import com.fidesmo.ble.client.protocol.SimplePacketFragmenter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class CustomPacketFragmenter implements PacketFragmenter {
+    public static final int HEADER_SIZE = 4;
+    private final int maxLength;
+    private final byte[] buffer;
+    private final int totalPackets;
+    private int sentPackets = 0;
+
+    public CustomPacketFragmenter(int maxLength, byte[] buffer) {
+        if(maxLength <= HEADER_SIZE) {
+            throw new IllegalArgumentException("MTU size can not be less of equal to header size");
+        } else {
+            this.maxLength = maxLength;
+            this.buffer = Arrays.copyOf(buffer, buffer.length);
+            int packetMax = maxLength - HEADER_SIZE;
+            int carriedLen = Math.max(buffer.length, 1);
+            this.totalPackets = carriedLen / packetMax + (carriedLen % packetMax > 0?1:0);
+        }
+    }
+
+    public byte[] nextFragment() {
+        int available = this.maxLength - HEADER_SIZE;
+        int offset = available * this.sentPackets;
+        int len = Math.min(available, this.buffer.length - offset);
+        byte[] chunk = new byte[len + HEADER_SIZE];
+        BleUtils.packInt2(this.totalPackets, chunk, 0);
+        BleUtils.packInt2(++this.sentPackets, chunk, HEADER_SIZE/2);
+        System.arraycopy(this.buffer, offset, chunk, HEADER_SIZE, len);
+        return chunk;
+    }
+
+    public boolean hasMoreData() {
+        return this.sentPackets < this.totalPackets;
+    }
+
+    public static CustomFragmentationProtocol factory() {
+        return new CustomPacketFragmenter.Factory();
+    }
+
+    private static class Factory implements CustomFragmentationProtocol {
+        private Factory() {
+        }
+
+        public PacketFragmenter fragmenter(int mtu, byte[] buffer) {
+            return new CustomPacketFragmenter(mtu, buffer);
+        }
+
+        public CustomPacketDefragmenter deframenter() {
+            return new CustomPacketFragmenter.Builder();
+        }
+    }
+
+    public static class Builder implements CustomPacketDefragmenter {
+        private int totalNo;
+        private int packetNo;
+
+        List<byte[]> byteArray;
+
+        private Builder() {
+            byteArray = new ArrayList<>();
+            totalNo = 0;
+            packetNo = 0;
+        }
+
+        public void clear(){
+            byteArray.clear();
+            totalNo = 0;
+            packetNo = 0;
+        }
+
+        public void append(byte[] array){
+            totalNo = BleUtils.unpackInt2(array, 0);
+            packetNo = BleUtils.unpackInt2(array, HEADER_SIZE/2);
+            byte[] buffer = new byte[array.length - HEADER_SIZE];
+            System.arraycopy(array, HEADER_SIZE, buffer, 0, buffer.length);
+            byteArray.add(buffer);
+        }
+
+        public void add(byte[] array){
+            byteArray.add(array);
+        }
+
+        public byte[] getBuffer(){
+            byte[] retArray;
+            int totalSize = 0;
+
+            for(int i=0; i < byteArray.size();i++){
+                totalSize = totalSize + byteArray.get(i).length;
+            }
+
+            int copuCounter = 0;
+            if(totalSize > 0) {
+                retArray = new byte[totalSize];
+                for(int ii=0; ii < byteArray.size();ii++){
+                    byte[] tmpArr = byteArray.get(ii);
+                    System.arraycopy(tmpArr, 0, retArray,copuCounter,tmpArr.length);
+                    copuCounter = copuCounter + tmpArr.length;
+                }
+            }else{
+                retArray = new byte[]{};
+            }
+            return retArray;
+        }
+
+        public boolean complete() {
+            return totalNo == packetNo;
+        }
+
+        public boolean empty() { return totalNo == 0 && packetNo == 0; }
+    }
+}

--- a/app/src/main/java/com/fidesmo/ble/client/apdu/SimpleApduFragmenter.java
+++ b/app/src/main/java/com/fidesmo/ble/client/apdu/SimpleApduFragmenter.java
@@ -1,0 +1,64 @@
+package com.fidesmo.ble.client.apdu;
+
+import android.util.Log;
+
+import com.fidesmo.ble.client.BleUtils;
+import com.fidesmo.ble.client.Utils;
+
+/**
+ * This class splits big byte buffer formed by a list of apdus
+ * into a list of single apdus.
+ * Spec: https://github.com/fidesmo/apdu-over-ble/blob/master/spec/apdu-service-spec.md
+ *
+ * Created by Angel Anton on 30/05/17.
+ */
+
+public class SimpleApduFragmenter implements ApduFragmenter {
+
+    private int TOTAL_HEADER_SIZE = 2;
+    private int HEADER_SIZE = 2;
+
+    @Override
+    public byte[][] decode(byte[] encodedApdus) {
+        int totalNo = BleUtils.unpackInt2(encodedApdus, 0);
+        byte[][] apdus = new byte[totalNo][];
+        int acc = TOTAL_HEADER_SIZE;
+
+        for (int i = 0; i < totalNo; i++) {
+            int apduSize = BleUtils.unpackInt2(encodedApdus, acc);
+            byte[] apdu = new byte[apduSize];
+            acc += HEADER_SIZE;
+            System.arraycopy(encodedApdus, acc, apdu, 0, apduSize);
+            apdus[i] = apdu;
+            acc += apduSize;
+        }
+        return apdus;
+    }
+
+    @Override
+    public byte[] encode(byte[][] apdus) {
+        byte[] buffer = new byte[2];
+        BleUtils.packInt2(apdus.length, buffer, 0);
+        int acc = TOTAL_HEADER_SIZE;
+
+        for (int i = 0; i < apdus.length; i++) {
+            byte[] apdu = apdus[i];
+            buffer = ensureBuffer(buffer, buffer.length + HEADER_SIZE + apdu.length);
+            BleUtils.packInt2(apdu.length, buffer, acc);
+            acc += HEADER_SIZE;
+            System.arraycopy(apdu, 0, buffer, acc, apdu.length);
+            acc += apdu.length;
+        }
+
+        return buffer;
+    }
+
+    private byte[] ensureBuffer(byte[] buffer, int size) {
+        if (buffer.length < size) {
+            byte[] oldBuf = buffer;
+            buffer = new byte[size]; // + 256?
+            System.arraycopy(oldBuf, 0, buffer, 0, oldBuf.length);
+        }
+        return buffer;
+    }
+}


### PR DESCRIPTION
Hint for reviewer:

This code works right now. The next topic is to decide where to include it (as part of our lib or as a demo implementation)
- APDU fragmenter: https://github.com/fidesmo/apdu-over-ble-android/blob/descriptor-fix/app/src/main/java/com/fidesmo/ble/client/apdu/SimpleApduFragmenter.java . Just to fragment and defragment packets at APDU level ( a packet could contains more than one apdu)

- Custom defragmenter: https://github.com/fidesmo/apdu-over-ble-android/tree/descriptor-fix/app/src/main/java/com/fidesmo/ble/client/apdu (directory, check files starting with **Custom**)

- In Android, BLE reads or writes data in small chunks and sometimes this chunk size doesn't fit the *MTU* defined. That's why an extra logic is needed to start to read a _real_ packet and to completely read it: https://github.com/fidesmo/apdu-over-ble-android/blob/descriptor-fix/app/src/main/java/com/fidesmo/ble/client/BlePeripheralService.java#L251-L255 
or in case of read request: 
https://github.com/fidesmo/apdu-over-ble-android/blob/descriptor-fix/app/src/main/java/com/fidesmo/ble/client/BlePeripheralService.java#L223-L231



